### PR TITLE
Some fixes for Crystal v0.13.0

### DIFF
--- a/src/crustache/indent_io.cr
+++ b/src/crustache/indent_io.cr
@@ -23,7 +23,7 @@ class Crustache::IndentIO
 
   def write(s)
     start = 0
-    size = Util.size(s)
+    size = s.size
     i = 0
     while i < size
       if @eol_flag

--- a/src/crustache/parser.cr
+++ b/src/crustache/parser.cr
@@ -157,7 +157,7 @@ class Crustache::Parser
 
   private def scan(tag)
     i = 0
-    size = Util.size(tag)
+    size = tag.size
     while i < size
       unless read == tag[i]
         return false
@@ -170,7 +170,7 @@ class Crustache::Parser
 
   private def scan_until(tag, out_io)
     i = 0
-    size = Util.size(tag)
+    size = tag.size
     text = Slice(UInt8).new size
     while i < size
       if c = read

--- a/src/crustache/renderer.cr
+++ b/src/crustache/renderer.cr
@@ -56,7 +56,10 @@ class Crustache::Renderer
   end
 
   def output(o)
-    (@out_io as IndentIO).indent_flag_off if @out_io.is_a?(IndentIO)
+    if (out_io = @out_io).is_a?(IndentIO)
+      out_io.indent_flag_off
+    end
+
     if value = @context.lookup o.value
       if value.is_a?(-> String)
         io = MemoryIO.new value.call
@@ -68,11 +71,17 @@ class Crustache::Renderer
         Util.escape value.to_s, @out_io
       end
     end
-    (@out_io as IndentIO).indent_flag_on if @out_io.is_a?(IndentIO)
+
+    if (out_io = @out_io).is_a?(IndentIO)
+      out_io.indent_flag_on
+    end
   end
 
   def raw(r)
-    (@out_io as IndentIO).indent_flag_off if @out_io.is_a?(IndentIO)
+    if (out_io = @out_io).is_a?(IndentIO)
+      out_io.indent_flag_off
+    end
+
     if value = @context.lookup r.value
       if value.is_a?(-> String)
         io = MemoryIO.new value.call
@@ -84,7 +93,10 @@ class Crustache::Renderer
         @out_io << value.to_s
       end
     end
-    (@out_io as IndentIO).indent_flag_on if @out_io.is_a?(IndentIO)
+
+    if (out_io = @out_io).is_a?(IndentIO)
+      out_io.indent_flag_on
+    end
   end
 
   def partial(p)

--- a/src/crustache/renderer.cr
+++ b/src/crustache/renderer.cr
@@ -1,4 +1,3 @@
-require "html"
 require "./context"
 require "./filesystem"
 require "./indent_io"
@@ -64,9 +63,9 @@ class Crustache::Renderer
         t = Parser.new(@open_tag_default, @close_tag_default, io, value.to_s).parse
         io = MemoryIO.new io.size
         t.visit(Renderer.new @open_tag_default, @close_tag_default, @context, @fs, io)
-        @out_io << HTML.escape io.to_s
+        Util.escape io.to_s, @out_io
       else
-        @out_io << HTML.escape value.to_s
+        Util.escape value.to_s, @out_io
       end
     end
     (@out_io as IndentIO).indent_flag_on if @out_io.is_a?(IndentIO)

--- a/src/crustache/util.cr
+++ b/src/crustache/util.cr
@@ -1,11 +1,3 @@
 # :nodoc:
 module Crustache::Util
-  # Crystal will remove Slice or Array #length (#1363)
-  def self.size(col)
-    if col.responds_to?(:length)
-      col.length
-    else
-      col.size
-    end
-  end
 end

--- a/src/crustache/util.cr
+++ b/src/crustache/util.cr
@@ -1,3 +1,18 @@
 # :nodoc:
 module Crustache::Util
+  ESCAPE = {
+    '&' => "&amp;",
+    '<' => "&lt;",
+    '>' => "&gt;",
+    '"' => "&quot;",
+    '\'' => "&apos;",
+  }
+
+  # Since Crystal v0.13.0, `HTML.escape` escapes too many characters, it breaks
+  # Mustache spec compatibility. This utility method can keep it.
+  def self.escape(str, io)
+    str.each_char do |char|
+      io << ESCAPE.fetch(char, char)
+    end
+  end
 end


### PR DESCRIPTION
- Remove `Util.size`. It is no longer needed.
- Add `Util.escape` instead of `HTML.escape`. Since Crystal v0.13.0, `HTML.escape` escapes too many characters, it breaks Mustache spec compatibility.
