### PR TITLE
Fix codes for Crystal 0.16

### DIFF
--- a/src/crustache.cr
+++ b/src/crustache.cr
@@ -41,7 +41,7 @@ module Crustache
   end
 
   def self.render(tmpl, model, fs, io)
-    tmpl.visit Renderer.new OPEN_TAG, CLOSE_TAG, Context.new(model), fs, io
+    tmpl.visit Renderer.new OPEN_TAG, CLOSE_TAG, Context(typeof(Context.resolve_scope_type(model))).new(model), fs, io
   end
 end
 

--- a/src/crustache/renderer.cr
+++ b/src/crustache/renderer.cr
@@ -7,8 +7,8 @@ require "./syntax"
 require "./util"
 
   # :nodoc:
-class Crustache::Renderer
-  def initialize(@open_tag : Slice(UInt8), @close_tag : Slice(UInt8), @context : Context, @fs : FileSystem, @out_io : IO)
+class Crustache::Renderer(T)
+  def initialize(@open_tag : Slice(UInt8), @close_tag : Slice(UInt8), @context : Context(T), @fs : FileSystem, @out_io : IO)
     @open_tag_default = @open_tag
     @close_tag_default = @close_tag
   end
@@ -117,10 +117,9 @@ class Crustache::Renderer
   end
 
   private def scope(ctx)
-    @context = Context.new(ctx, @context)
-    yield
-    @context = @context.parent as Context
-    nil
+    @context.scope(ctx) do
+      yield
+    end
   end
 end
 

--- a/src/crustache/syntax.cr
+++ b/src/crustache/syntax.cr
@@ -21,7 +21,7 @@ module Crustache::Syntax
     def initialize(@content : Array(Node)); end
 
     def <<(data)
-      unless data.is_a?(Text) && data.value.empty?
+      unless data.is_a?(Text) && data.value.not_nil!.empty?
         @content << data
       end
       self
@@ -56,7 +56,7 @@ module Crustache::Syntax
     class {{ type.id }} < Template
       include Tag
 
-      def initialize(@value : String, @content : Array(Node)); end
+      def initialize(@value : String, @content = [] of Node); end
 
       macro def to_code(io) : Nil
         io << "::\{{ @type.name.id }}.new("


### PR DESCRIPTION
- Add type annotations to instance variables because Crystal v0.16.0 requires it.
- Fix `Crustache::Context` type for above addings.
