### PR TITLE
Fix IndentIO#write return type for Crystal 0.35.1

### DIFF
--- a/src/crustache/indent_io.cr
+++ b/src/crustache/indent_io.cr
@@ -20,7 +20,7 @@ class Crustache::IndentIO < IO
   end
 
   {% begin %}
-    def write(s) : {% if compare_versions(Crystal::VERSION, "0.35.0") >= 0 %}Int64{% else %}Nil{% end %}
+    def write(s) : {% if compare_versions(Crystal::VERSION, "0.35.0") >= 0 %}Int64|Nil{% else %}Nil{% end %}
       start = 0
       size = s.size
       i = 0

--- a/src/crustache/indent_io.cr
+++ b/src/crustache/indent_io.cr
@@ -20,7 +20,7 @@ class Crustache::IndentIO < IO
   end
 
   {% begin %}
-    def write(s) : {% if compare_versions(Crystal::VERSION, "0.35.0") >= 0 %}Int64|Nil{% else %}Nil{% end %}
+    def write(s) : {% if compare_versions(Crystal::VERSION, "0.35.0") == 0 %}Int64{% else %}Nil{% end %}
       start = 0
       size = s.size
       i = 0


### PR DESCRIPTION
Hi @MakeNowJust,

This `PR` allow IO.write to retun `Nil`

Related to https://github.com/crystal-lang/crystal/pull/9469

Regards,