### PR TITLE
Use GitHub Actions instead of Travis CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: test
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "45 3 * * 6" # Runs at 03:45, only on Saturday
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: latest
+      - run: crystal spec

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spec/mustache-spec"]
 	path = spec/mustache-spec
-	url = git://github.com/mustache/spec.git
+	url = https://github.com/mustache/spec.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: crystal
-script:
-  - crystal spec

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ crustache is the implementation of __[mustache](https://mustache.github.io/)__ l
 
 This library implemated [mustache's spec v1.1.2+λ](https://github.com/mustache/spec/tree/v1.1.2).
 
-[![travis-ci.org](https://img.shields.io/travis/MakeNowJust/crustache.svg?style=flat-square)](https://travis-ci.org/MakeNowJust/crustache)
+[![test](https://github.com/makenowjust/crustache/actions/workflows/test.yml/badge.svg)](https://github.com/makenowjust/crustache/actions/workflows/test.yml)
 <!-- [![docrystal.org](http://www.docrystal.org/badge.svg)](http://www.docrystal.org/github.com/MakeNowJust/crustache) -->
 
 ## Installation


### PR DESCRIPTION
Hi @makenowjust 

I recently had the opportunity to use the mustache file format. 
And I came here looking for the Crystal library.
Travis CI was down so I rewrote it to GitHub Actions.
Thank you in advance for your help.

This GitHub Actions worked fine in my forked repository.
https://github.com/kojix2/crustache/actions/runs/8261960438